### PR TITLE
chore(renovate): require a 7 day cooldown before Actions automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,7 @@
       "description": "Low-risk: GitHub Actions minor and patch",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "7 days",
       "addLabels": ["automerge"],
       "automerge": true,
       "platformAutomerge": true


### PR DESCRIPTION
Renovate automerges github-actions minor and patch updates here with no `minimumReleaseAge`, so an action release can reach main minutes after it is published. The gomod rules in this same config already require 7 days; the github-actions rule was left without it.

This adds `"minimumReleaseAge": "7 days"` to that rule, so an action version has to be a week old before Renovate opens the PR that automerges it.

https://withpersona.atlassian.net/browse/INFR-3998

🤖 Generated with Claude Code
